### PR TITLE
Fix all remaining guild ID references: - Update scheduleTagRoleSync t…

### DIFF
--- a/src/features/stats/statsUpdater.js
+++ b/src/features/stats/statsUpdater.js
@@ -86,7 +86,7 @@ export async function scheduleTagRoleSync(client) {
   setInterval(async () => {
     try {
       console.log('🔄 Running periodic tag role sync...');
-      const guild = client.guilds.cache.first();
+      const guild = client.guilds.cache.get(process.env.GUILD_ID);
       if (!guild) {
         console.error('❌ No guild found for periodic tag sync');
         return;

--- a/src/utils/moderationLogger.js
+++ b/src/utils/moderationLogger.js
@@ -3,7 +3,7 @@ import channelsConfig from '../config/channels.json' with { type: 'json' };
 
 export const logModerationAction = async (client, action, targetUser, moderator, reason, duration = null) => {
   try {
-    const guild = client.guilds.cache.first();
+    const guild = client.guilds.cache.get(process.env.GUILD_ID);
     if (!guild) return;
 
     const logChannel = await guild.channels.fetch(channelsConfig.logChannelId);
@@ -43,7 +43,7 @@ export const logModerationAction = async (client, action, targetUser, moderator,
 
 export const logRoleAssignment = async (client, member, role, assignedBy = null) => {
   try {
-    const guild = client.guilds.cache.first();
+    const guild = client.guilds.cache.get(process.env.GUILD_ID);
     if (!guild) return;
 
     const logChannel = guild.channels.cache.get(channelsConfig.logChannelId);


### PR DESCRIPTION
…o use process.env.GUILD_ID - Update moderationLogger to use process.env.GUILD_ID - Remove all instances of client.guilds.cache.first()